### PR TITLE
Installing from npm/yarn there's no way to use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "dist",
+    "sass",
     "LICENSE",
     "README.md"
   ]


### PR DESCRIPTION
After adding to my project it occurs that cssgrid folder has only LICENSE, package.json and README.md 